### PR TITLE
Fix delayed server shutdown, fix @Mixin inspection

### DIFF
--- a/src/main/java/com/ultimateboomer/smoothboot/LoggingForkJoinWorkerThread.java
+++ b/src/main/java/com/ultimateboomer/smoothboot/LoggingForkJoinWorkerThread.java
@@ -1,0 +1,25 @@
+package com.ultimateboomer.smoothboot;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import org.apache.logging.log4j.Logger;
+
+public class LoggingForkJoinWorkerThread extends ForkJoinWorkerThread {
+	private final Logger logger;
+
+	public LoggingForkJoinWorkerThread(ForkJoinPool pool, Logger logger) {
+		super(pool);
+		this.logger = logger;
+	}
+
+	@Override
+	protected void onTermination(Throwable throwable) {
+		if (throwable != null) {
+			logger.warn("{} died", this.getName(), throwable);
+		} else {
+			logger.debug("{} shutdown", this.getName());
+		}
+
+		super.onTermination(throwable);
+	}
+}


### PR DESCRIPTION
I see you got it to work on servers too! I immediately went to test and it's such an improvement!
However, I noticed that server shutdowns are sometimes delayed by ~10 seconds and the server log showed this:

> [23:47:02] [Server thread/INFO] (MinecraftServer) Stopping server
> [23:47:02] [Server thread/INFO] (MinecraftServer) Saving players
> [23:47:02] [Server thread/INFO] (MinecraftServer) Saving worlds
> [23:47:02] [Server thread/INFO] (MinecraftServer) Saving chunks for level 'ServerLevel[worldtest]'/minecraft:overworld
> [23:47:03] [Server thread/INFO] (class_3898) ThreadedAnvilChunkStorage (worldtest): All chunks are saved
> [23:47:03] [Server thread/INFO] (MinecraftServer) Saving chunks for level 'ServerLevel[worldtest]'/minecraft:the_nether
> [23:47:03] [Server thread/INFO] (smoothboot) Initialized IO-Worker-22
> [23:47:03] [IO-Worker-22/INFO] (smoothboot) Initialized IO-Worker-23
> [23:47:03] [Server thread/INFO] (class_3898) ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
> [23:47:03] [Server thread/INFO] (class_3898) ThreadedAnvilChunkStorage (worldtest): All chunks are saved
> [23:47:03] [Server thread/INFO] (class_3898) ThreadedAnvilChunkStorage (DIM-1): All chunks are saved
> [23:47:03] [Server thread/INFO] (smoothboot) Initialized IO-Worker-24

So it was immediately clear what's happening: Worker threads are being created (or at least used) that then block the JVM from exiting until they get garbage collected and destroyed.
The fix is a simple `thread.setDaemon(true)`, this should have not effect on stability if Minecraft joins on it's workers - I think we would all know if it didn't.


As for the other changes, there's a `@Mixin` inspection saying

> Anonymous classes are not allowed in a `@Mixin` class

That is also found in the [documentation](https://docs.spongepowered.org/stable/en/contributing/implementation/mixins.html#mixins-and-inner-classes).
I therefore named the previously anonymous class, though I don't see any logging taking place before or after the changes?
It's the `Util` classes logger and I don't know where to actually see the log, maybe I misconfigured something?


The `Objects.equals(name, "Bootstrap")` change is a small one.
While `==` is fine in this case because "Bootstrap" gets interned, `String.equals` is always to be preferred (it starts with `==` anyways), `Objects.equals` uses `==` followed by `String.equals` and is also `null` safe.