### PR TITLE
Disable SmoothBoot (Forge) when data generation is running

### DIFF
--- a/src/main/java/io/github/ultimateboomer/smoothboot/SmoothBootState.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/SmoothBootState.java
@@ -2,4 +2,6 @@ package io.github.ultimateboomer.smoothboot;
 
 public class SmoothBootState {
 	public static boolean initConfig = false;
+
+	public static boolean mcIsRunningDatagen = false;
 }

--- a/src/main/java/io/github/ultimateboomer/smoothboot/config/SmoothBootConfig.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/config/SmoothBootConfig.java
@@ -12,7 +12,7 @@ public class SmoothBootConfig {
 	private int mainPriority = 1;
 	private int ioPriority = 1;
 	private int modLoadingPriority = 1;
-	
+
 	/**
 	 * Make sure the config values are within range
 	 */

--- a/src/main/java/io/github/ultimateboomer/smoothboot/config/SmoothBootConfigHandler.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/config/SmoothBootConfigHandler.java
@@ -12,11 +12,11 @@ import io.github.ultimateboomer.smoothboot.SmoothBoot;
 public class SmoothBootConfigHandler {
 	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 	public static SmoothBootConfig config;
-	
+
 	public static void readConfig() throws IOException {
 		String configPath = System.getProperty("user.dir") + "/config/" + SmoothBoot.MOD_ID + ".json";
 		SmoothBoot.LOGGER.debug("Config path: " + configPath);
-		
+
 		// Read config
 		try (FileReader reader = new FileReader(configPath)) {
 			config = GSON.fromJson(reader, SmoothBootConfig.class);
@@ -27,7 +27,7 @@ public class SmoothBootConfigHandler {
 			try (FileWriter writer = new FileWriter(configPath)) {
 				GSON.toJson(config, writer);
 			}
-			
+
 			SmoothBoot.LOGGER.debug("Config: " + config);
 		} catch (NullPointerException | JsonParseException | IOException e) {
 			// Create new config

--- a/src/main/java/io/github/ultimateboomer/smoothboot/mixin/DatagenModLoaderMixin.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/mixin/DatagenModLoaderMixin.java
@@ -1,0 +1,30 @@
+package io.github.ultimateboomer.smoothboot.mixin;
+
+import io.github.ultimateboomer.smoothboot.SmoothBootState;
+import net.minecraftforge.fml.DatagenModLoader;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Set;
+
+@Mixin(DatagenModLoader.class)
+public class DatagenModLoaderMixin {
+	@Shadow
+	private static boolean runningDataGen;
+
+	@Inject(method = "begin(Ljava/util/Set;Ljava/nio/file/Path;Ljava/util/Collection;Ljava/util/Collection;ZZZZZZ)V", at = @At(value = "INVOKE", target = "net/minecraft/util/registry/Bootstrap.register()V"), remap = false)
+	private static void begin(final Set<String> mods, final Path path, final java.util.Collection<Path> inputs,
+							  Collection<Path> existingPacks, final boolean serverGenerators,
+							  final boolean clientGenerators, final boolean devToolGenerators,
+							  final boolean reportsGenerator, final boolean structureValidator, final boolean flat,
+							  CallbackInfo ci) {
+		if (runningDataGen) {
+			SmoothBootState.mcIsRunningDatagen = true;
+		}
+	}
+}

--- a/src/main/java/io/github/ultimateboomer/smoothboot/mixin/ModWorkManagerMixin.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/mixin/ModWorkManagerMixin.java
@@ -3,6 +3,7 @@ package io.github.ultimateboomer.smoothboot.mixin;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 
+import io.github.ultimateboomer.smoothboot.SmoothBootState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
@@ -10,17 +11,22 @@ import io.github.ultimateboomer.smoothboot.SmoothBoot;
 import io.github.ultimateboomer.smoothboot.config.SmoothBootConfigHandler;
 
 import net.minecraftforge.fml.ModWorkManager;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ModWorkManager.class)
 public class ModWorkManagerMixin {
-	@Overwrite(remap = false)
-	private static ForkJoinWorkerThread newForkJoinWorkerThread(ForkJoinPool pool) {
-		ForkJoinWorkerThread thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
-		String workerName = "modloading-worker-" + thread.getPoolIndex();
-		SmoothBoot.LOGGER.debug("Initialized " + workerName);
-		thread.setName("modloading-worker-" + thread.getPoolIndex());
-		thread.setPriority(SmoothBootConfigHandler.config.getModLoadingPriority());
-		thread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
-		return thread;
+	@Inject(method = "newForkJoinWorkerThread(Ljava/util/concurrent/ForkJoinPool;)Ljava/util/concurrent/ForkJoinWorkerThread;", at = @At("HEAD"), cancellable = true, remap = false)
+	private static void newForkJoinWorkerThread(ForkJoinPool pool, CallbackInfoReturnable<ForkJoinWorkerThread> ci) {
+		if (!SmoothBootState.mcIsRunningDatagen) {
+			ForkJoinWorkerThread thread = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+			String workerName = "modloading-worker-" + thread.getPoolIndex();
+			SmoothBoot.LOGGER.debug("Initialized " + workerName);
+			thread.setName("modloading-worker-" + thread.getPoolIndex());
+			thread.setPriority(SmoothBootConfigHandler.config.getModLoadingPriority());
+			thread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+			ci.setReturnValue(thread);
+		}
 	}
 }

--- a/src/main/java/io/github/ultimateboomer/smoothboot/mixin/UtilMixin.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/mixin/UtilMixin.java
@@ -37,18 +37,19 @@ public abstract class UtilMixin {
 
 	@Shadow
 	private static ExecutorService RENDERING_SERVICE;
-	
+
 	@Shadow
 	@Final
 	private static AtomicInteger NEXT_SERVER_WORKER_ID;
-	
+
 	@Shadow
 	@Final
 	private static Logger LOGGER;
-	
+
 	@Shadow
-	private static void printException(Thread thread, Throwable throwable) {};
-	
+	private static void printException(Thread thread, Throwable throwable) {
+	}
+
 	// Probably not ideal, but this is the only way I found to modify createWorker without causing errors.
 	// Redirecting or overwriting causes static initialization to be called too early resulting in NullPointerException being thrown.
 	@Overwrite
@@ -83,12 +84,12 @@ public abstract class UtilMixin {
 
 		return RENDERING_SERVICE;
 	}
-	
+
 	// Replace createNamedService
 	private static ExecutorService replWorker(String name) {
 		SmoothBootConfig config = SmoothBootConfigHandler.config;
 		return new ForkJoinPool(MathHelper.clamp(select(name, config.getBootstrapThreads(),
-			config.getMainThreads()), 1, 0x7fff), (forkJoinPool) -> {
+				config.getMainThreads()), 1, 0x7fff), (forkJoinPool) -> {
 			String workerName = "Worker-" + name + NEXT_SERVER_WORKER_ID.getAndIncrement();
 			SmoothBoot.LOGGER.debug("Initialized " + workerName);
 
@@ -98,12 +99,12 @@ public abstract class UtilMixin {
 			return forkJoinWorkerThread;
 		}, UtilMixin::printException, true);
 	}
-	
+
 	private static ExecutorService replIoWorker() {
 		return Executors.newCachedThreadPool((p_240978_0_) -> {
 			String workerName = "IO-Worker-" + NEXT_SERVER_WORKER_ID.getAndIncrement();
 			SmoothBoot.LOGGER.debug("Initialized " + workerName);
-			
+
 			Thread thread = new Thread(p_240978_0_);
 			thread.setName(workerName);
 			thread.setPriority(SmoothBootConfigHandler.config.getIoPriority());
@@ -111,7 +112,7 @@ public abstract class UtilMixin {
 			return thread;
 		});
 	}
-	
+
 	private static <T> T select(String name, T bootstrap, T main) {
 		return Objects.equal(name, "Bootstrap") ? bootstrap : main;
 	}

--- a/src/main/java/io/github/ultimateboomer/smoothboot/mixin/UtilMixin.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/mixin/UtilMixin.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.github.ultimateboomer.smoothboot.SmoothBootState;
 import io.github.ultimateboomer.smoothboot.config.SmoothBootConfig;
 import io.github.ultimateboomer.smoothboot.config.SmoothBootConfigHandler;
 import org.apache.logging.log4j.Logger;
@@ -46,13 +47,13 @@ public abstract class UtilMixin {
 	private static Logger LOGGER;
 	
 	@Shadow
-	protected static void printException(Thread thread, Throwable throwable) {};
+	private static void printException(Thread thread, Throwable throwable) {};
 	
 	// Probably not ideal, but this is the only way I found to modify createWorker without causing errors.
 	// Redirecting or overwriting causes static initialization to be called too early resulting in NullPointerException being thrown.
 	@Overwrite
 	public static Executor getBootstrapService() {
-		if (!initBootstrapExecutor) {
+		if (!initBootstrapExecutor && !SmoothBootState.mcIsRunningDatagen) {
 			BOOTSTRAP_SERVICE = replWorker("Bootstrap");
 			initBootstrapExecutor = true;
 			SmoothBoot.LOGGER.debug("Replaced Bootstrap Executor");
@@ -63,7 +64,7 @@ public abstract class UtilMixin {
 
 	@Overwrite
 	public static Executor getServerExecutor() {
-		if (!initMainWorkerExecutor) {
+		if (!initMainWorkerExecutor && !SmoothBootState.mcIsRunningDatagen) {
 			SERVER_EXECUTOR = replWorker("Main");
 			initMainWorkerExecutor = true;
 			SmoothBoot.LOGGER.debug("Replaced Main Executor");
@@ -74,28 +75,28 @@ public abstract class UtilMixin {
 
 	@Overwrite
 	public static Executor getRenderingService() {
-		if (!initIoWorker) {
+		if (!initIoWorker && !SmoothBootState.mcIsRunningDatagen) {
 			RENDERING_SERVICE = replIoWorker();
 			initIoWorker = true;
 			SmoothBoot.LOGGER.debug("Replaced IO Executor");
 		}
+
 		return RENDERING_SERVICE;
 	}
 	
 	// Replace createNamedService
 	private static ExecutorService replWorker(String name) {
 		SmoothBootConfig config = SmoothBootConfigHandler.config;
-		ExecutorService executorService2 = new ForkJoinPool(MathHelper.clamp(select(name, config.getBootstrapThreads(),
+		return new ForkJoinPool(MathHelper.clamp(select(name, config.getBootstrapThreads(),
 			config.getMainThreads()), 1, 0x7fff), (forkJoinPool) -> {
 			String workerName = "Worker-" + name + NEXT_SERVER_WORKER_ID.getAndIncrement();
 			SmoothBoot.LOGGER.debug("Initialized " + workerName);
-			
+
 			ForkJoinWorkerThread forkJoinWorkerThread = new LoggingForkJoinWorkerThread(forkJoinPool, LOGGER);
 			forkJoinWorkerThread.setPriority(select(name, config.getBootstrapPriority(), config.getMainPriority()));
 			forkJoinWorkerThread.setName(workerName);
 			return forkJoinWorkerThread;
 		}, UtilMixin::printException, true);
-		return executorService2;
 	}
 	
 	private static ExecutorService replIoWorker() {

--- a/src/main/java/io/github/ultimateboomer/smoothboot/mixin/client/IntegratedServerMixin.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/mixin/client/IntegratedServerMixin.java
@@ -3,6 +3,7 @@ package io.github.ultimateboomer.smoothboot.mixin.client;
 import com.mojang.authlib.GameProfileRepository;
 import com.mojang.authlib.minecraft.MinecraftSessionService;
 import io.github.ultimateboomer.smoothboot.SmoothBoot;
+import io.github.ultimateboomer.smoothboot.SmoothBootState;
 import io.github.ultimateboomer.smoothboot.config.SmoothBootConfig;
 import io.github.ultimateboomer.smoothboot.config.SmoothBootConfigHandler;
 import net.minecraft.client.Minecraft;
@@ -28,7 +29,9 @@ public class IntegratedServerMixin {
                        MinecraftSessionService p_i232494_8_, GameProfileRepository p_i232494_9_,
                        PlayerProfileCache p_i232494_10_, IChunkStatusListenerFactory p_i232494_11_,
                        CallbackInfo ci) {
-        p_i232494_1_.setPriority(SmoothBootConfigHandler.config.getIntegratedServerPriority());
-        SmoothBoot.LOGGER.debug("Initialized integrated server thread");
+        if (!SmoothBootState.mcIsRunningDatagen) {
+            p_i232494_1_.setPriority(SmoothBootConfigHandler.config.getIntegratedServerPriority());
+            SmoothBoot.LOGGER.debug("Initialized integrated server thread");
+        }
     }
 }

--- a/src/main/java/io/github/ultimateboomer/smoothboot/mixin/client/IntegratedServerMixin.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/mixin/client/IntegratedServerMixin.java
@@ -22,16 +22,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(IntegratedServer.class)
 public class IntegratedServerMixin {
-    @Inject(method = "<init>", at = @At("RETURN"))
-    public void onInit(Thread p_i232494_1_, Minecraft p_i232494_2_, DynamicRegistries.Impl p_i232494_3_,
-                       SaveFormat.LevelSave p_i232494_4_, ResourcePackList p_i232494_5_,
-                       DataPackRegistries p_i232494_6_, IServerConfiguration p_i232494_7_,
-                       MinecraftSessionService p_i232494_8_, GameProfileRepository p_i232494_9_,
-                       PlayerProfileCache p_i232494_10_, IChunkStatusListenerFactory p_i232494_11_,
-                       CallbackInfo ci) {
-        if (!SmoothBootState.mcIsRunningDatagen) {
-            p_i232494_1_.setPriority(SmoothBootConfigHandler.config.getIntegratedServerPriority());
-            SmoothBoot.LOGGER.debug("Initialized integrated server thread");
-        }
-    }
+	@Inject(method = "<init>", at = @At("RETURN"))
+	public void onInit(Thread p_i232494_1_, Minecraft p_i232494_2_, DynamicRegistries.Impl p_i232494_3_,
+					   SaveFormat.LevelSave p_i232494_4_, ResourcePackList p_i232494_5_,
+					   DataPackRegistries p_i232494_6_, IServerConfiguration p_i232494_7_,
+					   MinecraftSessionService p_i232494_8_, GameProfileRepository p_i232494_9_,
+					   PlayerProfileCache p_i232494_10_, IChunkStatusListenerFactory p_i232494_11_,
+					   CallbackInfo ci) {
+		if (!SmoothBootState.mcIsRunningDatagen) {
+			p_i232494_1_.setPriority(SmoothBootConfigHandler.config.getIntegratedServerPriority());
+			SmoothBoot.LOGGER.debug("Initialized integrated server thread");
+		}
+	}
 }

--- a/src/main/java/io/github/ultimateboomer/smoothboot/mixin/client/MainMixin.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/mixin/client/MainMixin.java
@@ -17,12 +17,14 @@ import net.minecraft.client.main.Main;
 public class MainMixin {
 	@Inject(method = "main", at = @At("HEAD"), remap = false)
 	private static void onMain(CallbackInfo ci) throws IOException {
-		if (!SmoothBootState.initConfig) {
-			SmoothBootConfigHandler.readConfig();
-			SmoothBootState.initConfig = true;
+		if (!SmoothBootState.mcIsRunningDatagen) {
+			if (!SmoothBootState.initConfig) {
+				SmoothBootConfigHandler.readConfig();
+				SmoothBootState.initConfig = true;
+			}
+
+			Thread.currentThread().setPriority(SmoothBootConfigHandler.config.getGamePriority());
+			SmoothBoot.LOGGER.debug("Initialized client game thread");
 		}
-		
-		Thread.currentThread().setPriority(SmoothBootConfigHandler.config.getGamePriority());
-		SmoothBoot.LOGGER.debug("Initialized client game thread");
 	}
 }

--- a/src/main/java/io/github/ultimateboomer/smoothboot/mixin/server/MainMixin.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/mixin/server/MainMixin.java
@@ -17,12 +17,14 @@ import net.minecraft.server.Main;
 public class MainMixin {
 	@Inject(method = "main", at = @At("HEAD"), remap = false)
 	private static void onMain(CallbackInfo ci) throws IOException {
-		if (!SmoothBootState.initConfig) {
-			SmoothBootConfigHandler.readConfig();
-			SmoothBootState.initConfig = true;
+		if (!SmoothBootState.mcIsRunningDatagen) {
+			if (!SmoothBootState.initConfig) {
+				SmoothBootConfigHandler.readConfig();
+				SmoothBootState.initConfig = true;
+			}
+
+			Thread.currentThread().setPriority(SmoothBootConfigHandler.config.getGamePriority());
+			SmoothBoot.LOGGER.debug("Initialized server game thread");
 		}
-		
-		Thread.currentThread().setPriority(SmoothBootConfigHandler.config.getGamePriority());
-		SmoothBoot.LOGGER.debug("Initialized server game thread");
 	}
 }

--- a/src/main/resources/smoothboot.mixins.json
+++ b/src/main/resources/smoothboot.mixins.json
@@ -4,12 +4,13 @@
 	"compatibilityLevel": "JAVA_8",
 	"refmap": "smoothboot.refmap.json",
 	"mixins": [
-		"UtilMixin",
-		"ModWorkManagerMixin"
+		"DatagenModLoaderMixin",
+		"ModWorkManagerMixin",
+		"UtilMixin"
 	],
 	"client": [
-		"client.MainMixin",
-		"client.IntegratedServerMixin"
+		"client.IntegratedServerMixin",
+		"client.MainMixin"
 	],
 	"server": [
 		"server.MainMixin"


### PR DESCRIPTION
This PR disables all of SmoothBoot's modifications when `DatagenModLoaderMixin` has found that data generation is running. This fixes #11 but if you have a better way of doing this than just disabling everything, feel free to let me know. I'll be honest, I have no idea how the hell SmoothBoot works, so this is the best I could do.