### PR TITLE
Fixing Default Thread Count Calculation

### DIFF
--- a/src/main/java/io/github/ultimateboomer/smoothboot/config/SmoothBootConfig.java
+++ b/src/main/java/io/github/ultimateboomer/smoothboot/config/SmoothBootConfig.java
@@ -7,13 +7,13 @@ public class SmoothBootConfig {
 	public ThreadCount threadCount = new ThreadCount();
 
 	public ThreadPriority threadPriority = new ThreadPriority();
-	
+
 	public static class ThreadCount {
 		public int bootstrap = 1;
-		public int main = MathHelper.clamp(Runtime.getRuntime().availableProcessors() - 1, 1,
+		public int main = MathHelper.clamp(Runtime.getRuntime().availableProcessors() / 2, 1,
 				SmoothBoot.getMaxBackgroundThreads());
 	}
-	
+
 	public static class ThreadPriority {
 		public int game = 5;
 		public int bootstrap = 1;
@@ -33,4 +33,3 @@ public class SmoothBootConfig {
 		threadPriority.io = MathHelper.clamp(threadPriority.io, 1, 10);
 	}
 }
- 


### PR DESCRIPTION
As I discussed in https://github.com/UltimateBoomer/mc-smoothboot/issues/34, the Smooth Boot wiki states that Smooth Boot's default Main Worker Thread Count is `1/2 of total CPU threads`. However, the auto-generated default value I found in my config `.json` was not consistent with this stated intention.

I suspected that the wiki stated the _plan_ or _intention_, but the code was inconsistent with this plan, so I looked through the code to find where the default values were generated.

I found it.

I propose that we change the code to reflect the sensible plan set forth in the wiki.
